### PR TITLE
fixed a bug where we added the event listener in the constructor but …

### DIFF
--- a/src/CommunityToolkit.Maui/Behaviors/Validators/LayoutValidationBehavior.shared.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/Validators/LayoutValidationBehavior.shared.cs
@@ -43,13 +43,17 @@ public class LayoutValidationBehavior : BaseValidationBehavior
 	{
 		Behaviors = new List<BaseValidationBehavior>();
 		DefaultVariableMultiValueConverter = new VariableMultiValueConverter { ConditionType = MultiBindingCondition.All };
+	}
+	static object CreateDefaultConverter(BindableObject bindable) => ((LayoutValidationBehavior)bindable).DefaultVariableMultiValueConverter;
+
+	protected override void OnAttachedTo(BindableObject bindable)
+	{
+		base.OnAttachedTo(bindable);
 		if (View != null)
 		{
 			View.DescendantAdded += OnDescendantAdded;
 		}
 	}
-	static object CreateDefaultConverter(BindableObject bindable) => ((LayoutValidationBehavior)bindable).DefaultVariableMultiValueConverter;
-
 	///<inheritdoc/>
 	protected override BindingBase CreateBinding()
 	{


### PR DESCRIPTION
…by that time the behavior would not be attached. so the view would be null, and we wouldn't be able to listen for the descendants being added.

<!--
Hello, and thanks for your interest in contributing to the .NET MAUI Toolkit! 

For Bug Fixes:
If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request. Bug Fix Pull Requests without an associated Issue will be closed.

For New Feature Proposals:
If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
-->

## Fixes
<!-- Please link to the Issue that this Pull Request resolves -->

## Description

<!-- Please copy/paste the Description/Summary from your Issue-->

## Detailed Solution

<!-- Please describe the solution in detail-->